### PR TITLE
[BUGFIX] Remove deprecated function create_function

### DIFF
--- a/Classes/Hooks/UrlRewritingHook.php
+++ b/Classes/Hooks/UrlRewritingHook.php
@@ -1141,7 +1141,9 @@ class UrlRewritingHook implements SingletonInterface
 
         // Convert URL to segments
         $pathParts = explode('/', $speakingURIpath);
-        array_walk($pathParts, create_function('&$value', '$value = urldecode($value);'));
+        array_walk($pathParts, function(&$value) {
+			$value = urldecode($value);
+		});
 
         // Strip/process file name or extension first
         $file_GET_VARS = $this->decodeSpURL_decodeFileName($pathParts);


### PR DESCRIPTION
The function create_function is deprecated from PHP 7.2. 

Since TYPO3 9.0 requires PHP 7.2 it's safe to remove it and replace it with a anonymous function