### PR TITLE
[BUGFIX] Use array_map instead of array_walk with create_function

### DIFF
--- a/Classes/Hooks/UrlRewritingHook.php
+++ b/Classes/Hooks/UrlRewritingHook.php
@@ -1140,7 +1140,7 @@ class UrlRewritingHook implements SingletonInterface
 
         // Convert URL to segments
         $pathParts = explode('/', $speakingURIpath);
-        array_walk($pathParts, create_function('&$value', '$value = urldecode($value);'));
+        array_walk($pathParts, function(&$value) { $value = urldecode($value); });
 
         // Strip/process file name or extension first
         $file_GET_VARS = $this->decodeSpURL_decodeFileName($pathParts);

--- a/Classes/Hooks/UrlRewritingHook.php
+++ b/Classes/Hooks/UrlRewritingHook.php
@@ -1140,7 +1140,7 @@ class UrlRewritingHook implements SingletonInterface
 
         // Convert URL to segments
         $pathParts = explode('/', $speakingURIpath);
-        array_walk($pathParts, function(&$value) { $value = urldecode($value); });
+        $pathParts = array_map('urldecode', $pathParts);
 
         // Strip/process file name or extension first
         $file_GET_VARS = $this->decodeSpURL_decodeFileName($pathParts);


### PR DESCRIPTION
Since PHP 7.2 create_function throws a PHP Runtime Deprecation Notice.
This patch replace the create_function call with a closure function.