### PR TITLE
[!!!][TASK] Migrate to doctrine and drop redirects

### DIFF
--- a/Classes/Hooks/DataHandling/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandling/DataHandlerHook.php
@@ -145,8 +145,8 @@ class DataHandlerHook implements SingletonInterface
                         'value_id' => (int)$recordId
                     ],
                     [
-                        Connection::PARAM_INT,
                         Connection::PARAM_STR,
+                        Connection::PARAM_INT
                     ]
 
                 );

--- a/Resources/Private/Templates/RedirectView.html
+++ b/Resources/Private/Templates/RedirectView.html
@@ -7,6 +7,6 @@
 	Please perform a migration if you want to continue using these redirects.</p>
 </f:be.infobox>
 
-<f:be.link route="site_redirects" parameters="{1:1}" class="btn btn-primary">To the redirects module</f:be.link>
+<f:be.link route="site_redirects" class="btn btn-primary">To the redirects module</f:be.link>
 
 </html>

--- a/Resources/Private/Templates/RedirectView.html
+++ b/Resources/Private/Templates/RedirectView.html
@@ -1,0 +1,12 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+
+<f:be.infobox title="Realurl does no longer support the redirect feature." state="1">
+	<p><strong>Redirects are in the Core now!</strong><br />
+	Please migrate your redirects to the <em>sys_redirect</em> table of the TYPO3 core.</p>
+	<p>The table tx_realurl_redirects is still in your database.
+	Please perform a migration if you want to continue using these redirects.</p>
+</f:be.infobox>
+
+<f:be.link route="site_redirects" parameters="{1:1}" class="btn btn-primary">To the redirects module</f:be.link>
+
+</html>


### PR DESCRIPTION
This patch migrates the final parts of the extension
(the administration module) to doctrine based
querries.

Also the redirect functionality of realurl is dropped
entirely in favor of the redirect functionality of the
TYPO3 core. However, the database table containing the
redirects is still in place to enable a migration.